### PR TITLE
Add an explicit noop option for minimal containers that do not have echo

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -146,6 +146,19 @@ dns:
   - 9.9.9.9
 ```
 
+### noop
+
+Specify a explicit no-op command for use during intermediate container creation with
+minimal images that don't have `echo`. For example [hello-world](https://registry.hub.docker.com/u/library/hello-world/).
+
+```
+datavol:
+  image: hello-world
+  noop: /hello
+  volume:
+    - /mydata
+```
+
 ### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged
 
 Each of these is a single value, analogous to its [docker run](https://docs.docker.com/reference/run/) counterpart.

--- a/fig/service.py
+++ b/fig/service.py
@@ -58,7 +58,7 @@ class Service(object):
         if 'image' in options and 'build' in options:
             raise ConfigError('Service %s has both an image and build path specified. A service can either be built to image or use an existing image, not both.' % name)
 
-        supported_options = DOCKER_CONFIG_KEYS + ['build', 'expose']
+        supported_options = DOCKER_CONFIG_KEYS + ['build', 'expose', 'noop']
 
         for k in options:
             if k not in supported_options:
@@ -223,7 +223,7 @@ class Service(object):
         intermediate_container = Container.create(
             self.client,
             image=container.image,
-            entrypoint=['echo'],
+            entrypoint=self.options.get('noop', ['echo']),
             command=[],
         )
         intermediate_container.start(volumes_from=container.id)

--- a/tests/fixtures/datavolume-figfile/fig.yml
+++ b/tests/fixtures/datavolume-figfile/fig.yml
@@ -1,0 +1,17 @@
+datam:
+  image: hello-world
+  noop: /hello
+  volumes:
+    - /avolume
+
+dataw:
+  image: debian:7
+  volumes:
+    - /another
+
+app:
+  image: figtest_test
+  command: [ "/bin/true" ]
+  volumes_from:
+    - datam
+    - dataw

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -129,6 +129,16 @@ class CLITestCase(DockerClientTestCase):
 
         self.assertEqual(old_ids, new_ids)
 
+    def test_up_with_minimal_data_volume(self):
+        self.command.base_dir = 'tests/fixtures/datavolume-figfile'
+        self.command.dispatch(['up', '-d'], None)
+        service = self.project.get_service('app')
+        self.assertEqual(len(service.containers()), 1)
+
+        self.command.dispatch(['up', '-d'], None)
+        service = self.project.get_service('app')
+        self.assertEqual(len(service.containers()), 0)
+
     @patch('dockerpty.start')
     def test_run_service_without_links(self, mock_stdout):
         self.command.base_dir = 'tests/fixtures/links-figfile'


### PR DESCRIPTION
In order to support data only volumes using minimal images #514 I have added an option that allows a no-op command to be explicitly specified - currently it is assumed to be echo which isn't necessarily available on a minimal image.

I have added a test and updated the documentation.

I am concerned that this approach essentially exposes an internal feature ...