### PR TITLE
Convert project_name to lowercase

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -81,7 +81,7 @@ class Command(DocoptCommand):
 
     def get_project_name(self, config_path, project_name=None):
         def normalize_name(name):
-            return re.sub(r'[^a-zA-Z0-9]', '', name)
+            return re.sub(r'[^a-z0-9]', '', name.lower())
 
         project_name = project_name or os.environ.get('FIG_PROJECT_NAME')
         if project_name is not None:

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -29,6 +29,12 @@ class CLITestCase(unittest.TestCase):
         project_name = command.get_project_name(command.get_config_path())
         self.assertEquals('simplefigfile', project_name)
 
+    def test_project_name_with_explicit_uppercase_base_dir(self):
+        command = TopLevelCommand()
+        command.base_dir = 'tests/fixtures/Simple-figfile'
+        project_name = command.get_project_name(command.get_config_path())
+        self.assertEquals('simplefigfile', project_name)
+
     def test_project_name_with_explicit_project_name(self):
         command = TopLevelCommand()
         name = 'explicit-project-name'


### PR DESCRIPTION
```bash
$ fig up
Creating FIGtest_test_1...
Building test...
Invalid repository name (FIGtest_test), only [a-z0-9-_.] are allowed
$ cat fig.yml 
test:
  build: test/
$ cat test/Dockerfile 
FROM scratch
$ basename $(pwd)
FIG-test
```

IMHO `.` and `-` could be allowed in the a `normalize_name` method too. What is your opinion?