### PR TITLE
Added support of cpuset and memswap_limit options in fig.yml.

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -142,7 +142,7 @@ dns:
   - 9.9.9.9
 ```
 
-### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged
+### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, cpuset, memswap_limit
 
 Each of these is a single value, analogous to its [docker run](https://docs.docker.com/reference/run/) counterpart.
 
@@ -156,4 +156,6 @@ domainname: foo.com
 
 mem_limit: 1000000000
 privileged: true
+cpuset: “0-3,5”
+memswap_limit: 1024
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.5.3
+docker-py==0.6.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.5.3, < 0.6',
+    'docker-py == 0.6',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -17,6 +17,7 @@ from fig.service import (
     parse_volume_spec,
     build_volume_binding,
     APIError,
+    parse_cpuset,
 )
 
 
@@ -205,6 +206,27 @@ class ServiceTest(unittest.TestCase):
         self.mock_client.pull.assert_called_once_with('someimage:sometag', insecure_registry=True, stream=True)
         mock_log.info.assert_called_once_with('Pulling image someimage:sometag...')
 
+    def test_valid_parse_cpusets(self):
+        valid_cpuset = "1,2,3-4,5"
+        valid_cpuset_spaced = "4, 2, 3-4 , 5"
+        self.assertEqual(parse_cpuset(None), None)
+        self.assertEqual(parse_cpuset(''), None)
+        self.assertEqual(parse_cpuset(valid_cpuset), valid_cpuset)
+        self.assertEqual(parse_cpuset(valid_cpuset_spaced), valid_cpuset_spaced)
+
+    def test_invalid_parse_cpusets(self):
+        with self.assertRaises(ConfigError):
+            parse_cpuset("1-")
+        with self.assertRaises(ConfigError):
+            parse_cpuset("1-2,")
+        with self.assertRaises(ConfigError):
+            parse_cpuset("4,")
+        with self.assertRaises(ConfigError):
+            parse_cpuset("1-3-4")
+        with self.assertRaises(ConfigError):
+            parse_cpuset("1-3-4-1-2-2-")
+        with self.assertRaises(ConfigError):
+            parse_cpuset("1-2,2,a")
 
 class ServiceVolumesTest(unittest.TestCase):
 


### PR DESCRIPTION
I added support for cpuset and memswap_limit options. unfortunately cpuset support was only added on docker-py 0.6, so i updated the setup.py and requirements.txt to use 0.6 (i saw there is already an open PR on this #659 ). 