### PR TITLE
Fix volumes on recreate

### DIFF
--- a/fig/project.py
+++ b/fig/project.py
@@ -176,18 +176,14 @@ class Project(object):
            do_build=True):
         running_containers = []
         for service in self.get_services(service_names, include_links=start_links):
-            if recreate:
-                for (_, container) in service.recreate_containers(
-                        insecure_registry=insecure_registry,
+            create_func = (service.recreate_containers if recreate
+                           else service.start_or_create_containers)
+
+            for container in create_func(
+                    insecure_registry=insecure_registry,
                         detach=detach,
                         do_build=do_build):
-                    running_containers.append(container)
-            else:
-                for container in service.start_or_create_containers(
-                        insecure_registry=insecure_registry,
-                        detach=detach,
-                        do_build=do_build):
-                    running_containers.append(container)
+                running_containers.append(container)
 
         return running_containers
 

--- a/fig/project.py
+++ b/fig/project.py
@@ -181,8 +181,8 @@ class Project(object):
 
             for container in create_func(
                     insecure_registry=insecure_registry,
-                        detach=detach,
-                        do_build=do_build):
+                    detach=detach,
+                    do_build=do_build):
                 running_containers.append(container)
 
         return running_containers

--- a/fig/service.py
+++ b/fig/service.py
@@ -242,8 +242,9 @@ class Service(object):
 
     def recreate_containers(self, insecure_registry=False, do_build=True, **override_options):
         """
-        If a container for this service doesn't exist, create and start one. If there are
-        any, stop them, create+start new ones, and remove the old containers.
+        If a container for this service doesn't exist, create and start one. If
+        there are any, stop them, create+start new ones, and remove the old
+        containers.
         """
         containers = self.containers(stopped=True)
         if not containers:
@@ -253,21 +254,22 @@ class Service(object):
                 do_build=do_build,
                 **override_options)
             self.start_container(container)
-            return [(None, container)]
+            return [container]
         else:
-            tuples = []
-
-            for c in containers:
-                log.info("Recreating %s..." % c.name)
-                tuples.append(self.recreate_container(c, insecure_registry=insecure_registry, **override_options))
-
-            return tuples
+            return [
+                self.recreate_container(
+                    container,
+                    insecure_registry=insecure_registry,
+                    **override_options)
+                for container in containers
+            ]
 
     def recreate_container(self, container, **override_options):
         """Recreate a container. An intermediate container is created so that
         the new container has the same name, while still supporting
         `volumes-from` the original container.
         """
+        log.info("Recreating %s..." % container.name)
         try:
             container.stop()
         except APIError as e:
@@ -295,7 +297,7 @@ class Service(object):
 
         intermediate_container.remove()
 
-        return (intermediate_container, new_container)
+        return new_container
 
     def start_container_if_stopped(self, container, **options):
         if container.is_running:

--- a/fig/service.py
+++ b/fig/service.py
@@ -280,6 +280,7 @@ class Service(object):
             else:
                 raise
 
+        intermediate_options = dict(self.options, **override_options)
         intermediate_container = Container.create(
             self.client,
             image=container.image,
@@ -287,16 +288,21 @@ class Service(object):
             command=[],
             detach=True,
         )
-        intermediate_container.start(volumes_from=container.id)
+        intermediate_container.start(
+            binds=get_container_data_volumes(
+                container, intermediate_options.get('volumes')))
         intermediate_container.wait()
         container.remove()
 
+        # TODO: volumes are being passed to both start and create, this is
+        # probably unnecessary
         options = dict(override_options)
         new_container = self.create_container(do_build=False, **options)
-        self.start_container(new_container, intermediate_container=intermediate_container)
+        self.start_container(
+            new_container,
+            intermediate_container=intermediate_container)
 
         intermediate_container.remove()
-
         return new_container
 
     def start_container_if_stopped(self, container, **options):
@@ -309,12 +315,6 @@ class Service(object):
     def start_container(self, container, intermediate_container=None, **override_options):
         options = dict(self.options, **override_options)
         port_bindings = build_port_bindings(options.get('ports') or [])
-
-        volume_bindings = dict(
-            build_volume_binding(parse_volume_spec(volume))
-            for volume in options.get('volumes') or []
-            if ':' in volume)
-
         privileged = options.get('privileged', False)
         net = options.get('net', 'bridge')
         dns = options.get('dns', None)
@@ -323,12 +323,14 @@ class Service(object):
         cap_drop = options.get('cap_drop', None)
 
         restart = parse_restart_spec(options.get('restart', None))
+        binds = get_volume_bindings(
+            options.get('volumes'), intermediate_container)
 
         container.start(
             links=self._get_links(link_to_self=options.get('one_off', False)),
             port_bindings=port_bindings,
-            binds=volume_bindings,
-            volumes_from=self._get_volumes_from(intermediate_container),
+            binds=binds,
+            volumes_from=self._get_volumes_from(),
             privileged=privileged,
             network_mode=net,
             dns=dns,
@@ -390,7 +392,7 @@ class Service(object):
             links.append((external_link, link_name))
         return links
 
-    def _get_volumes_from(self, intermediate_container=None):
+    def _get_volumes_from(self):
         volumes_from = []
         for volume_source in self.volumes_from:
             if isinstance(volume_source, Service):
@@ -403,9 +405,6 @@ class Service(object):
 
             elif isinstance(volume_source, Container):
                 volumes_from.append(volume_source.id)
-
-        if intermediate_container:
-            volumes_from.append(intermediate_container.id)
 
         return volumes_from
 
@@ -519,6 +518,45 @@ class Service(object):
                 image_name,
                 insecure_registry=insecure_registry
             )
+
+
+def get_container_data_volumes(container, volumes_option):
+    """Find the container data volumes that are in `volumes_option`, and return
+    a mapping of volume bindings for those volumes.
+    """
+    volumes = []
+    for volume in volumes_option or []:
+        volume = parse_volume_spec(volume)
+        # No need to preserve host volumes
+        if volume.external:
+            continue
+
+        volume_path = (container.get('Volumes') or {}).get(volume.internal)
+        # New volume, doesn't exist in the old container
+        if not volume_path:
+            continue
+
+        # Copy existing volume from old container
+        volume = volume._replace(external=volume_path)
+        volumes.append(build_volume_binding(volume))
+
+    return dict(volumes)
+
+
+def get_volume_bindings(volumes_option, intermediate_container):
+    """Return a list of volume bindings for a container. Container data volume
+    bindings are replaced by those in the intermediate container.
+    """
+    volume_bindings = dict(
+        build_volume_binding(parse_volume_spec(volume))
+        for volume in volumes_option or []
+        if ':' in volume)
+
+    if intermediate_container:
+        volume_bindings.update(
+            get_container_data_volumes(intermediate_container, volumes_option))
+
+    return volume_bindings
 
 
 NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?(\d+)$')

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -148,30 +148,23 @@ class ServiceTest(DockerClientTestCase):
         self.assertIn('FOO=1', old_container.dictionary['Config']['Env'])
         self.assertEqual(old_container.name, 'figtest_db_1')
         service.start_container(old_container)
-        volume_path = old_container.inspect()['Volumes']['/etc']
+        volume_path = old_container.get('Volumes')['/etc']
 
         num_containers_before = len(self.client.containers(all=True))
 
         service.options['environment']['FOO'] = '2'
-        tuples = service.recreate_containers()
-        self.assertEqual(len(tuples), 1)
+        containers = service.recreate_containers()
+        self.assertEqual(len(containers), 1)
 
-        intermediate_container = tuples[0][0]
-        new_container = tuples[0][1]
-        self.assertEqual(intermediate_container.dictionary['Config']['Entrypoint'], ['/bin/echo'])
-
-        self.assertEqual(new_container.dictionary['Config']['Entrypoint'], ['sleep'])
-        self.assertEqual(new_container.dictionary['Config']['Cmd'], ['300'])
-        self.assertIn('FOO=2', new_container.dictionary['Config']['Env'])
+        new_container = containers[0]
+        self.assertEqual(new_container.get('Config.Entrypoint'), ['sleep'])
+        self.assertEqual(new_container.get('Config.Cmd'), ['300'])
+        self.assertIn('FOO=2', new_container.get('Config.Env'))
         self.assertEqual(new_container.name, 'figtest_db_1')
-        self.assertEqual(new_container.inspect()['Volumes']['/etc'], volume_path)
-        self.assertIn(intermediate_container.id, new_container.dictionary['HostConfig']['VolumesFrom'])
+        self.assertEqual(new_container.get('Volumes')['/etc'], volume_path)
 
         self.assertEqual(len(self.client.containers(all=True)), num_containers_before)
         self.assertNotEqual(old_container.id, new_container.id)
-        self.assertRaises(APIError,
-                          self.client.inspect_container,
-                          intermediate_container.id)
 
     def test_recreate_containers_when_containers_are_stopped(self):
         service = self.create_service(

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -11,13 +11,15 @@ from requests import Response
 from fig import Service
 from fig.container import Container
 from fig.service import (
-    ConfigError,
-    split_port,
-    build_port_bindings,
-    parse_volume_spec,
-    build_volume_binding,
     APIError,
+    ConfigError,
+    build_port_bindings,
+    build_volume_binding,
+    get_container_data_volumes,
+    get_volume_bindings,
     parse_repository_tag,
+    parse_volume_spec,
+    split_port,
 )
 
 
@@ -56,13 +58,6 @@ class ServiceTest(unittest.TestCase):
             volumes_from=[mock.Mock(id=container_id, spec=Container)])
 
         self.assertEqual(service._get_volumes_from(), [container_id])
-
-    def test_get_volumes_from_intermediate_container(self):
-        container_id = 'aabbccddee'
-        service = Service('test')
-        container = mock.Mock(id=container_id, spec=Container)
-
-        self.assertEqual(service._get_volumes_from(container), [container_id])
 
     def test_get_volumes_from_service_container_exists(self):
         container_ids = ['aabbccddee', '12345']
@@ -287,6 +282,50 @@ class ServiceVolumesTest(unittest.TestCase):
         self.assertEqual(
             binding,
             ('/home/user', dict(bind='/home/user', ro=False)))
+
+    def test_get_container_data_volumes(self):
+        options = [
+            '/host/volume:/host/volume:ro',
+            '/new/volume',
+            '/existing/volume',
+        ]
+
+        container = Container(None, {
+            'Volumes': {
+                '/host/volume':     '/host/volume',
+                '/existing/volume': '/var/lib/docker/aaaaaaaa',
+                '/removed/volume':  '/var/lib/docker/bbbbbbbb',
+            },
+        }, has_been_inspected=True)
+
+        expected = {
+            '/var/lib/docker/aaaaaaaa': {'bind': '/existing/volume', 'ro': False},
+        }
+
+        binds = get_container_data_volumes(container, options)
+        self.assertEqual(binds, expected)
+
+    def test_get_volume_bindings(self):
+        options = [
+            '/host/volume:/host/volume:ro',
+            '/host/rw/volume:/host/rw/volume',
+            '/new/volume',
+            '/existing/volume',
+        ]
+
+        intermediate_container = Container(None, {
+            'Volumes': {'/existing/volume': '/var/lib/docker/aaaaaaaa'},
+            }, has_been_inspected=True)
+
+        expected = {
+            '/host/volume': {'bind': '/host/volume', 'ro': True},
+            '/host/rw/volume': {'bind': '/host/rw/volume', 'ro': False},
+            '/var/lib/docker/aaaaaaaa': {'bind': '/existing/volume', 'ro': False},
+        }
+
+        binds = get_volume_bindings(options, intermediate_container)
+        self.assertEqual(binds, expected)
+
 
 class ServiceEnvironmentTest(unittest.TestCase):
 


### PR DESCRIPTION
Resolves: #447 (and probably some other related issues)

Instead of using `volumes_from` on the intermediate container, inspect the volumes, and copy them over the to intermediate container and from the intermediate to the final container.