### PR TITLE
Support the Fig template on docker swarm 

### DIFF
--- a/fig/container.py
+++ b/fig/container.py
@@ -32,8 +32,6 @@ class Container(object):
 
     @classmethod
     def create(cls, client, **options):
-        if is_cluster_mode():
-            options['detach'] = True
         response = client.create_container(**options)
         return cls.from_id(client, response['Id'])
 
@@ -155,7 +153,6 @@ class Container(object):
             for name in container['Names']:
                 if name.startswith(prefix) :
                     links.append(name[prefix.length + 1:])
-        print links
         return links
 
     def attach(self, *args, **kwargs):
@@ -171,3 +168,4 @@ class Container(object):
         if type(self) != type(other):
             return False
         return self.id == other.id
+

--- a/fig/utils.py
+++ b/fig/utils.py
@@ -1,6 +1,5 @@
 from cli import docker_client
 
-
 cluster_mode = None
 
 def find_container_name(names):
@@ -14,8 +13,11 @@ def find_container_name(names):
                 return values[1]
 
 def find_container_name_with_host(names):
+    n = 2
+    if is_cluster_mode():
+        n = 3
     for name in names:
-        if len(name.split('/')) == 3:
+        if len(name.split('/')) == n:
             return name
 
 def get_container_name_without_host(name):
@@ -30,9 +32,8 @@ def is_cluster_mode():
         info = docker_client.docker_client().info()
         driverStatus = info['DriverStatus']
         for status in driverStatus:
-            print status
             if isinstance(status, list) and status[0] == u'\x08Nodes':
                 cluster_mode = True
                 break
-
     return cluster_mode
+

--- a/fig/utils.py
+++ b/fig/utils.py
@@ -1,0 +1,38 @@
+from cli import docker_client
+
+
+cluster_mode = None
+
+def find_container_name(names):
+    for name in names:
+        values = name.split('/')
+        if is_cluster_mode():
+            if len(values) == 3:
+                return values[2]
+        else:
+            if len(values) == 2:
+                return values[1]
+
+def find_container_name_with_host(names):
+    for name in names:
+        if len(name.split('/')) == 3:
+            return name
+
+def get_container_name_without_host(name):
+    names = name.split('/')
+    return names[len(names) - 1]
+
+
+def is_cluster_mode():
+    global cluster_mode
+    if cluster_mode == None:
+        cluster_mode = False
+        info = docker_client.docker_client().info()
+        driverStatus = info['DriverStatus']
+        for status in driverStatus:
+            print status
+            if isinstance(status, list) and status[0] == u'\x08Nodes':
+                cluster_mode = True
+                break
+
+    return cluster_mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.6.0
+docker-py==0.7.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.6.0, < 0.7',
+    'docker-py >= 0.7.0, < 0.8',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
The current Fig can only support the single Docker host deployment. To enable it work on Docker Swarm, 

1. Add the logic to let Fig detect if it works on single node mode or cluster mode in fig/utils.py
2. Enable Fig work properly with new container naming convention with host name from cluster mode in fig/container.py and fig/service.py
3. Modify the logic of container creation for port binding to make swarm scheduler can handle the port conflicting.  

To enable the fully function work on Docker Swarm, there will be some changes in the cluster scheduling and network connectivity for cross-host linking. There are also other fixes for Swarm in https://github.com/denverdino/swarm

And there is one sample Vagrant project to setup the Docker Swarm cluster with changes in Docker Swarm to handle the cross-host linking with Ambassador pattern, and it will also create the flat network among the Docker containers across the cluster. 

Please refer the project in https://github.com/denverdino/docker-swarm-vagrant

Thanks and Happy New Year!


