### PR TITLE
Support fig on swarm cluster

### DIFF
--- a/fig/cli/docker_client.py
+++ b/fig/cli/docker_client.py
@@ -32,4 +32,4 @@ def docker_client():
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version='1.14', timeout=timeout)
+    return Client(base_url=base_url, tls=tls_config, version='1.15', timeout=timeout)

--- a/fig/container.py
+++ b/fig/container.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
-
+from .utils import find_container_name_with_host, is_cluster_mode
 import six
 
 
@@ -23,9 +23,7 @@ class Container(object):
             'Id': dictionary['Id'],
             'Image': dictionary['Image'],
         }
-        for name in dictionary.get('Names', []):
-            if len(name.split('/')) == 2:
-                new_dictionary['Name'] = name
+        new_dictionary['Name'] = find_container_name_with_host(dictionary.get('Names', []))
         return cls(client, new_dictionary, **kwargs)
 
     @classmethod
@@ -150,11 +148,14 @@ class Container(object):
 
     def links(self):
         links = []
+        n = 2
+        if is_cluster_mode():
+            n = 3
         for container in self.client.containers():
             for name in container['Names']:
                 bits = name.split('/')
-                if len(bits) > 2 and bits[1] == self.name:
-                    links.append(bits[2])
+                if len(bits) > n and bits[n - 1] == self.name:
+                    links.append(bits[n])
         return links
 
     def attach(self, *args, **kwargs):

--- a/fig/utils.py
+++ b/fig/utils.py
@@ -1,0 +1,39 @@
+from cli import docker_client
+
+cluster_mode = None
+
+
+def find_container_name(names):
+    for name in names:
+        values = name.split('/')
+        if is_cluster_mode():
+            if len(values) == 3:
+                return values[2]
+        else:
+            if len(values) == 2:
+                return values[1]
+
+
+def find_container_name_with_host(names):
+    n = 2
+    if is_cluster_mode():
+        n = 3
+    for name in names:
+        if len(name.split('/')) == n:
+            return name
+
+
+def get_container_name_without_host(name):
+    names = name.split('/')
+    return names[len(names) - 1]
+
+
+def is_cluster_mode():
+    global cluster_mode
+    if cluster_mode is None:
+        cluster_mode = False
+        info = docker_client.docker_client().version()
+        version = info['Version']
+        if version.startswith('swarm/'):
+            cluster_mode = True
+    return cluster_mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.6.0
+docker-py==0.7.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.6.0, < 0.7',
+    'docker-py >= 0.7.0, < 0.8',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
To enable fig works on Docker Swarm,

1. Add the logic to let Fig detect if it works on single node mode or cluster mode in fig/utils.py
2. Enable Fig work properly with new container naming convention with host name from cluster mode in fig/container.py and fig/service.py
3. Modify the logic of container creation for port binding to make swarm scheduler can handle the port conflicting.

To enable the fully function work on Docker Swarm, there will be some changes in the cluster scheduling and network connectivity for cross-host linking. There are also other enhancement for Swarm in https://github.com/denverdino/swarm

And there is one sample Vagrant project to setup the Docker Swarm cluster with changes in Docker Swarm to handle the cross-host linking with Ambassador pattern, and it will also create the flat network among the Docker containers across the cluster.

Please refer the project in https://github.com/denverdino/docker-swarm-vagrant

Thanks