### PR TITLE
Add cpu_shares option in fig.yml

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -194,11 +194,13 @@ dns_search:
   - dc2.example.com
 ```
 
-### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, restart, stdin\_open, tty
+### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, restart, stdin\_open, tty, cpu\_shares
 
 Each of these is a single value, analogous to its [docker run](https://docs.docker.com/reference/run/) counterpart.
 
 ```
+cpu_shares: 73
+
 working_dir: /code
 entrypoint: /code/entrypoint.sh
 user: postgresql

--- a/fig/service.py
+++ b/fig/service.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 DOCKER_CONFIG_KEYS = [
     'cap_add',
     'cap_drop',
+    'cpu_shares',
     'command',
     'detach',
     'dns',
@@ -41,6 +42,7 @@ DOCKER_CONFIG_KEYS = [
     'working_dir',
 ]
 DOCKER_CONFIG_HINTS = {
+    'cpu_share' : 'cpu_shares',
     'link'      : 'links',
     'port'      : 'ports',
     'privilege' : 'privileged',

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -100,6 +100,12 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertIn('/var/db', container.inspect()['Volumes'])
 
+    def test_create_container_with_cpu_shares(self):
+        service = self.create_service('db', cpu_shares=73)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.inspect()['Config']['CpuShares'], 73)
+
     def test_create_container_with_specified_volume(self):
         host_path = '/tmp/host-path'
         container_path = '/container-path'


### PR DESCRIPTION
This options maps exactly the docker run option with the same name.

Signed-off-by: Christophe Labouisse <christophe@labouisse.org>