### PR TITLE
Handle Swarm-style prefixed container names

### DIFF
--- a/fig/container.py
+++ b/fig/container.py
@@ -22,10 +22,8 @@ class Container(object):
         new_dictionary = {
             'Id': dictionary['Id'],
             'Image': dictionary['Image'],
+            'Name': '/' + get_container_name(dictionary),
         }
-        for name in dictionary.get('Names', []):
-            if len(name.split('/')) == 2:
-                new_dictionary['Name'] = name
         return cls(client, new_dictionary, **kwargs)
 
     @classmethod
@@ -170,3 +168,14 @@ class Container(object):
         if type(self) != type(other):
             return False
         return self.id == other.id
+
+
+def get_container_name(container):
+    if not container.get('Name') and not container.get('Names'):
+        return None
+    # inspect
+    if 'Name' in container:
+        return container['Name']
+    # ps
+    shortest_name = min(container['Names'], key=lambda n: len(n.split('/')))
+    return shortest_name.split('/')[-1]

--- a/fig/service.py
+++ b/fig/service.py
@@ -545,9 +545,8 @@ def get_container_name(container):
     if 'Name' in container:
         return container['Name']
     # ps
-    for name in container['Names']:
-        if len(name.split('/')) == 2:
-            return name[1:]
+    shortest_name = min(container['Names'], key=lambda n: len(n.split('/')))
+    return shortest_name.split('/')[-1]
 
 
 def parse_restart_spec(restart_config):

--- a/fig/service.py
+++ b/fig/service.py
@@ -9,7 +9,7 @@ import sys
 
 from docker.errors import APIError
 
-from .container import Container
+from .container import Container, get_container_name
 from .progress_stream import stream_output, StreamOutputError
 
 log = logging.getLogger(__name__)
@@ -536,17 +536,6 @@ def parse_name(name):
     match = NAME_RE.match(name)
     (project, service_name, _, suffix) = match.groups()
     return ServiceName(project, service_name, int(suffix))
-
-
-def get_container_name(container):
-    if not container.get('Name') and not container.get('Names'):
-        return None
-    # inspect
-    if 'Name' in container:
-        return container['Name']
-    # ps
-    shortest_name = min(container['Names'], key=lambda n: len(n.split('/')))
-    return shortest_name.split('/')[-1]
 
 
 def parse_restart_spec(restart_config):

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -20,13 +20,25 @@ class ContainerTest(unittest.TestCase):
             "Ports": None,
             "SizeRw": 0,
             "SizeRootFs": 0,
-            "Names": ["/figtest_db_1"],
+            "Names": ["/figtest_db_1", "/figtest_web_1/db"],
             "NetworkSettings": {
                 "Ports": {},
             },
         }
 
     def test_from_ps(self):
+        container = Container.from_ps(None,
+                                      self.container_dict,
+                                      has_been_inspected=True)
+        self.assertEqual(container.dictionary, {
+            "Id": "abc",
+            "Image":"busybox:latest",
+            "Name": "/figtest_db_1",
+        })
+
+    def test_from_ps_prefixed(self):
+        self.container_dict['Names'] = ['/swarm-host-1' + n for n in self.container_dict['Names']]
+
         container = Container.from_ps(None,
                                       self.container_dict,
                                       has_been_inspected=True)

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -54,6 +54,7 @@ class ServiceTest(unittest.TestCase):
         self.assertIsNone(get_container_name({}))
         self.assertEqual(get_container_name({'Name': 'myproject_db_1'}), 'myproject_db_1')
         self.assertEqual(get_container_name({'Names': ['/myproject_db_1', '/myproject_web_1/db']}), 'myproject_db_1')
+        self.assertEqual(get_container_name({'Names': ['/swarm-host-1/myproject_db_1', '/swarm-host-1/myproject_web_1/db']}), 'myproject_db_1')
 
     def test_containers(self):
         service = Service('db', client=self.mock_client, project='myproject')
@@ -66,6 +67,17 @@ class ServiceTest(unittest.TestCase):
             {'Image': 'busybox', 'Id': 'OUT_2', 'Names': ['/myproject_db']},
             {'Image': 'busybox', 'Id': 'OUT_3', 'Names': ['/db_1']},
             {'Image': 'busybox', 'Id': 'IN_1', 'Names': ['/myproject_db_1', '/myproject_web_1/db']},
+        ]
+        self.assertEqual([c.id for c in service.containers()], ['IN_1'])
+
+    def test_containers_prefixed(self):
+        service = Service('db', client=self.mock_client, project='myproject')
+
+        self.mock_client.containers.return_value = [
+            {'Image': 'busybox', 'Id': 'OUT_1', 'Names': ['/swarm-host-1/myproject', '/swarm-host-1/foo/bar']},
+            {'Image': 'busybox', 'Id': 'OUT_2', 'Names': ['/swarm-host-1/myproject_db']},
+            {'Image': 'busybox', 'Id': 'OUT_3', 'Names': ['/swarm-host-1/db_1']},
+            {'Image': 'busybox', 'Id': 'IN_1', 'Names': ['/swarm-host-1/myproject_db_1', '/swarm-host-1/myproject_web_1/db']},
         ]
         self.assertEqual([c.id for c in service.containers()], ['IN_1'])
 


### PR DESCRIPTION
Related to #814.

Swarm prefixes all container names with an extra path component, breaking our name-finding logic when trying to get the "given" name of a container from the output of `/containers/json`.

The fix: instead of looking for a name with exactly one path component, we pick the shortest one (counting path components of course, not characters) out of the `Names` array.

ping @aluzzardi @vieux - what do you two think of this? Can we do something less hacky?