### PR TITLE
Test for preservation of volumes declared in images

### DIFF
--- a/tests/fixtures/dockerfile-with-volume/Dockerfile
+++ b/tests/fixtures/dockerfile-with-volume/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+VOLUME /data
+CMD sleep 3000


### PR DESCRIPTION
This test succeeds against 72095f54b26650affed47c3b888d77572d6ecbf0 (i.e. before the merge of #711). We weren't testing this case before.