### PR TITLE
Revert #711 from dnephin/fix_volumes_on_recreate

### DIFF
--- a/fig/project.py
+++ b/fig/project.py
@@ -176,14 +176,18 @@ class Project(object):
            do_build=True):
         running_containers = []
         for service in self.get_services(service_names, include_links=start_links):
-            create_func = (service.recreate_containers if recreate
-                           else service.start_or_create_containers)
-
-            for container in create_func(
-                    insecure_registry=insecure_registry,
-                    detach=detach,
-                    do_build=do_build):
-                running_containers.append(container)
+            if recreate:
+                for (_, container) in service.recreate_containers(
+                        insecure_registry=insecure_registry,
+                        detach=detach,
+                        do_build=do_build):
+                    running_containers.append(container)
+            else:
+                for container in service.start_or_create_containers(
+                        insecure_registry=insecure_registry,
+                        detach=detach,
+                        do_build=do_build):
+                    running_containers.append(container)
 
         return running_containers
 


### PR DESCRIPTION
Turns out this needs more testing.

There are some significant differences between docker 1.2  and 1.4.1 that aren't handled properly.

It would be awesome if we could setup wercker to test against at least a couple different versions of dockerd.