### PR TITLE
Update bash completion for compose 1.1.0-rc1

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -212,7 +212,7 @@ _docker-compose_run() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --entrypoint -e --no-deps --rm -T" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --entrypoint -e --no-deps --rm --service-ports -T" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_all


### PR DESCRIPTION
This adds `docker-compose run --service-ports`.
Support for `docker-compose kill -s SIGNAL` and `docker-compose up --no-build` was already added in my last PR.
With this, bash completion is in sync with the additions mentioned in the release notes.
