### PR TITLE
Fix test for image-declared volumes

### DIFF
--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -189,7 +189,7 @@ class ServiceTest(DockerClientTestCase):
 
     def test_recreate_containers_with_image_declared_volume(self):
         service = Service(
-            project='figtest',
+            project='composetest',
             name='db',
             client=self.client,
             build='tests/fixtures/dockerfile-with-volume',


### PR DESCRIPTION
A stray 'fig' got lost in the merge post-rename, meaning the containers weren't being cleaned up properly. Test was failing against Docker 1.4.1.