### PR TITLE
Fix database.yml file with port and database name

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -69,11 +69,11 @@ Open up your newly-generated `database.yml`. Replace its contents with the follo
     development: &default
       adapter: postgresql
       encoding: unicode
-      database: postgres
+      database: myapp
       pool: 5
       username: postgres
-      password:
       host: db
+      port: 5432
 
     test:
       <<: *default


### PR DESCRIPTION
the `postgres` database is the default database, you can't use it.

port should be filled cause the default strategy is connect by socks file