### PR TITLE
Ship 1.1.0-rc2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 Change log
 ==========
 
+1.1.0-rc2 (2015-01-29)
+----------------------
+
+On top of the changelog for 1.1.0-rc1 (see below), the following bugs have been fixed:
+
+- When an environment variables file specified with `env_file` doesn't exist, Compose was showing a stack trace instead of a helpful error.
+
+- Configuration files using the old name (`fig.yml`) were not being read unless explicitly specified with `docker-compose -f`. Compose now reads them and prints a deprecation warning.
+
+- Bash tab completion now reads `fig.yml` if it's present.
+
 1.1.0-rc1 (2015-01-20)
 ----------------------
 
@@ -27,6 +38,8 @@ Besides that, there’s a lot of new stuff in this release:
 - docker-compose.yml now has an `env_file` key, analogous to `docker run --env-file`, letting you specify multiple environment variables in a separate file. This is great if you have a lot of them, or if you want to keep sensitive information out of version control.
 
 - docker-compose.yml now supports the `dns_search`, `cap_add`, `cap_drop` and `restart` options, analogous to `docker run`’s `--dns-search`, `--cap-add`, `--cap-drop` and `--restart` options.
+
+- Compose now ships with Bash tab completion - see the installation and usage docs at https://github.com/docker/fig/blob/1.1.0-rc1/docs/completion.md
 
 - A number of bugs have been fixed - see the milestone for details: https://github.com/docker/fig/issues?q=milestone%3A1.1.0+
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import unicode_literals
 from .service import Service  # noqa:flake8
 
-__version__ = '1.1.0-rc1'
+__version__ = '1.1.0-rc2'

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -17,7 +17,7 @@ On a Mac, install with `brew install bash-completion`
  
 Place the completion script in `/etc/bash_completion.d/` (`/usr/local/etc/bash_completion.d/` on a Mac), using e.g. 
 
-     curl -L https://raw.githubusercontent.com/docker/docker-compose/master/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose
+     curl -L https://raw.githubusercontent.com/docker/fig/1.1.0-rc2/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose
  
 Completion will be available upon next login.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ There are also guides for [Ubuntu](https://docs.docker.com/installation/ubuntuli
 
 Next, install Compose:
 
-    curl -L https://github.com/docker/docker-compose/releases/download/1.1.0-rc1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose; chmod +x /usr/local/bin/docker-compose
+    curl -L https://github.com/docker/fig/releases/download/1.1.0-rc2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose; chmod +x /usr/local/bin/docker-compose
 
 Optionally, install [command completion](completion.html) for the bash shell.
 


### PR DESCRIPTION
The release notes for 1.1.0-rc2 will be an an amalgamation of the CHANGELOG.md entries for both RCs.