### PR TITLE
fix syntax errors indicated by pip

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -25,7 +25,7 @@ class Command(DocoptCommand):
     def dispatch(self, *args, **kwargs):
         try:
             super(Command, self).dispatch(*args, **kwargs)
-        except SSLError, e:
+        except SSLError as e:
             raise errors.UserError('SSL error: %s' % e)
         except ConnectionError:
             if call_silently(['which', 'docker']) != 0:

--- a/compose/service.py
+++ b/compose/service.py
@@ -481,7 +481,7 @@ class Service(object):
 
         try:
             all_events = stream_output(build_output, sys.stdout)
-        except StreamOutputError, e:
+        except StreamOutputError as e:
             raise BuildError(self, unicode(e))
 
         image_id = None


### PR DESCRIPTION
wthen we tried install docker-compose with pip - we get an syntax error