### PR TITLE
have setup.py read requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 mock >= 1.0.1
 nose
-git+https://github.com/pyinstaller/pyinstaller.git@12e40471c77f588ea5be352f7219c873ddaae056#egg=pyinstaller
+pyinstaller
 unittest2
 flake8

--- a/setup.py
+++ b/setup.py
@@ -24,23 +24,11 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-install_requires = [
-    'docopt >= 0.6.1, < 0.7',
-    'PyYAML >= 3.10, < 4',
-    'requests >= 2.2.1, < 3',
-    'texttable >= 0.8.1, < 0.9',
-    'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 0.6.0, < 0.8',
-    'dockerpty >= 0.3.2, < 0.4',
-    'six >= 1.3.0, < 2',
-]
+with open('requirements.txt') as reqs:
+    install_requires = reqs.read().splitlines()
 
-tests_require = [
-    'mock >= 1.0.1',
-    'nose',
-    'pyinstaller',
-    'flake8',
-]
+with open('requirements-dev.txt') as reqs:
+    tests_require = reqs.read().splitlines()
 
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
I was surprised to find the list of requirements was replicated inside 
setup.py as well in requirements.txt/requirements-dev.txt.  This change has
setup.py read the files so that the requirements only need to be maintained in
one place.