### PR TITLE
Tidy up contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,14 @@
 # Contributing to Compose
 
+Compose is a part of the Docker project, and follows the same rules and principles. Take a read of [Docker's contributing guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md) to get an overview.
+
 ## TL;DR
 
 Pull requests will need:
 
  - Tests
  - Documentation
- - [To be signed off](#sign-your-work)
+ - [To be signed off](https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work)
  - A logical series of [well written commits](https://github.com/alphagov/styleguides/blob/master/git.md)
 
 ## Development environment
@@ -23,50 +25,6 @@ that should get you started.
 ## Running the test suite
 
     $ script/test
-
-## Sign your work
-
-The sign-off is a simple line at the end of the explanation for the
-patch, which certifies that you wrote it or otherwise have the right to
-pass it on as an open-source patch.  The rules are pretty simple: if you
-can certify the below (from [developercertificate.org](http://developercertificate.org/)):
-
-    Developer's Certificate of Origin 1.1
-
-    By making a contribution to this project, I certify that:
-
-    (a) The contribution was created in whole or in part by me and I
-        have the right to submit it under the open source license
-        indicated in the file; or
-
-    (b) The contribution is based upon previous work that, to the best
-        of my knowledge, is covered under an appropriate open source
-        license and I have the right under that license to submit that
-        work with modifications, whether created in whole or in part
-        by me, under the same open source license (unless I am
-        permitted to submit under a different license), as indicated
-        in the file; or
-
-    (c) The contribution was provided directly to me by some other
-        person who certified (a), (b) or (c) and I have not modified
-        it.
-
-    (d) I understand and agree that this project and the contribution
-        are public and that a record of the contribution (including all
-        personal information I submit with it, including my sign-off) is
-        maintained indefinitely and may be redistributed consistent with
-        this project or the open source license(s) involved.
-
-then you just add a line saying
-
-    Signed-off-by: Random J Developer <random@developer.example.org>
-
-using your real name (sorry, no pseudonyms or anonymous contributions.)
-
-The easiest way to do this is to use the `--signoff` flag when committing. E.g.:
-
-
-    $ git commit --signoff
 
 ## Building binaries
 
@@ -100,5 +58,5 @@ Note that this only works on Mountain Lion, not Mavericks, due to a [bug in PyIn
 
 7. Upload PyPi package
 
-    $ git checkout $VERSION
-    $ python setup.py sdist upload
+        $ git checkout $VERSION
+        $ python setup.py sdist upload


### PR DESCRIPTION
- Add intro saying we roughly follow the Docker project's guidelines
- Link to Docker's signing off docs
- Fix formatting at bottom

Signed-off-by: Ben Firshman <ben@firshman.co.uk>